### PR TITLE
feat: add string extension method for palindrome detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: .NET CI
+
+on: [push, pull_request]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 9.0.x
+    
+    - name: Cache NuGet packages
+      uses: actions/cache@v3
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+    
+    - name: Restore dependencies
+      run: dotnet restore practice2025.sln
+    
+    - name: Build
+      run: dotnet build practice2025.sln -c Release --no-restore
+    
+    - name: Test
+      run: dotnet test task01tests/task01tests.csproj -c Release --no-build

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# .NET
+bin/
+obj/

--- a/practice2025.sln
+++ b/practice2025.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "task01", "task01\task01.csproj", "{AC0304B1-B866-4C1B-A2B2-08557B101D72}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "task01tests", "task01tests\task01tests.csproj", "{91A82557-053B-4157-8579-5B237F6D6DAD}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{AC0304B1-B866-4C1B-A2B2-08557B101D72}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AC0304B1-B866-4C1B-A2B2-08557B101D72}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AC0304B1-B866-4C1B-A2B2-08557B101D72}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AC0304B1-B866-4C1B-A2B2-08557B101D72}.Release|Any CPU.Build.0 = Release|Any CPU
+		{91A82557-053B-4157-8579-5B237F6D6DAD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{91A82557-053B-4157-8579-5B237F6D6DAD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{91A82557-053B-4157-8579-5B237F6D6DAD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{91A82557-053B-4157-8579-5B237F6D6DAD}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/task01/StringExtensions.cs
+++ b/task01/StringExtensions.cs
@@ -1,0 +1,12 @@
+public static class StringExtensions
+{
+	public static bool IsPalindrome(this string input)
+	{
+		var modifiedInput = input
+			.Where(x => !char.IsWhiteSpace(x) && !char.IsPunctuation(x))
+			.Select(char.ToLowerInvariant)
+			.ToArray();
+
+		return modifiedInput.Length > 0 && modifiedInput.SequenceEqual(modifiedInput.Reverse());
+	}
+}

--- a/task01/task01.csproj
+++ b/task01/task01.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/task01tests/StringExtensionsTests.cs
+++ b/task01tests/StringExtensionsTests.cs
@@ -1,0 +1,32 @@
+using Xunit;
+
+public class StringExtensionsTests
+{
+    [Fact]
+    public void IsPalindrome_ValidPalindrome_ReturnsTrue()
+    {
+        string input = "А роза упала на лапу Азора";
+        Assert.True(input.IsPalindrome());
+    }
+
+    [Fact]
+    public void IsPalindrome_NotPalindrome_ReturnsFalse()
+    {
+        string input = "Hello, world!";
+        Assert.False(input.IsPalindrome());
+    }
+
+    [Fact]
+    public void IsPalindrome_EmptyString_ReturnsFalse()
+    {
+        string input = "";
+        Assert.False(input.IsPalindrome());
+    }
+
+    [Fact]
+    public void IsPalindrome_WithPunctuation_IgnoresPunctuation()
+    {
+        string input = "Was it a car or a cat I saw?";
+        Assert.True(input.IsPalindrome());
+    }
+}

--- a/task01tests/task01tests.csproj
+++ b/task01tests/task01tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\task01\task01.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Implements a string extension method IsPalindrome() to StringExtensions class that checks if a string is a palindrome while ignoring case, whitespace, and punctuation.

Other:
- Added comprehensive xunit tests covering various cases
- Configured CI pipeline for automated testing